### PR TITLE
fix: raise AuthMissingParameter if there is no ticket

### DIFF
--- a/openedx_cas/backends.py
+++ b/openedx_cas/backends.py
@@ -60,7 +60,11 @@ class CASAuth(BaseAuth, CASBackend):
         :returns: [User] Authenticated User object or None if authenticate failed
         """
         request = kwargs["request"]
-        ticket = request.GET["ticket"]
+        ticket = request.GET.get("ticket", None)
+
+        if not ticket:
+            raise AuthMissingParameter(self, "ticket")
+
         response = self.cas_validation(request, ticket, settings.CAS_SERVICE_URL)
         kwargs.update({"response": response, "backend": self})
 


### PR DESCRIPTION
**Description:** When there is no a query param called `ticket` in the
auth_complete request and AuthMissingParameter exception is raised,
this way the exception is captured by ExceptionMiddleware and 
a proper error is raised.
