### PR TITLE
fix request without ticket

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ Change Log
    in this file.  It adheres to the structure of https://keepachangelog.com/ ,
    but in reStructuredText instead of Markdown (for ease of incorporation into
    Sphinx documentation and the PyPI description).
-   
+
    This project adheres to Semantic Versioning (https://semver.org/).
 
 .. There should always be an "Unreleased" section for changes pending release.
@@ -14,6 +14,13 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[0.2.3] - 2022-08-11
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Added
+_____
+
+* Added CAS_REDIRECT_WITHOUT_TICKET setting.
 
 [0.2.2] - 2022-07-27
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -49,6 +49,20 @@ The required configuration includes:
         "CAS_SERVICE_URL": "https://LMS_BASE/auth/complete/centralized-auth-service/?next=/"
     }
 
+Optional configuration:
+
+.. code-block:: json
+
+    {
+        "CAS_REDIRECT_WITHOUT_TICKET": true
+    }
+
+This settings allows you to modify the default behavior when the auth/complete backend receives a request without ticket. Usually when the user reset his password in the CAS Server and it's automatically redirected to the LMS.
+
+Expected behavior:
+    - true: Redirects to login automatically
+    - false: Raise an AuthMissingParameter exception
+
 We advise you to use the following third party auth pipeline:
 
 .. code-block:: json

--- a/openedx_cas/tests/test_backends.py
+++ b/openedx_cas/tests/test_backends.py
@@ -79,6 +79,38 @@ class TestOpenEdxCasAuthBackend(TestCase):
             backend=self.cas_backend
         )
 
+    @override_settings(CAS_REDIRECT_WITHOUT_TICKET=True)
+    @override_settings(LOGIN_URL="/login")
+    @patch('openedx_cas.backends.redirect')
+    def test_auth_complete_redirect_on_missing_ticket(self, redirect):
+        """
+        This method is used to verify that the flow is valid when the ticket is valid.
+
+        Expected behavior:
+        Response returned by auth_complete should include the correspoding values when the ticket is valid
+        """
+        service_response = {}
+        request = Mock(GET=service_response)
+
+        self.cas_backend.auth_complete(request=request)
+
+        redirect.assert_called_with(
+            settings.LOGIN_URL
+        )
+
+    @override_settings(CAS_REDIRECT_WITHOUT_TICKET=None)
+    def test_auth_complete_raises_on_missing_ticket(self):
+        """
+        This method is used to verify that the flow is valid when the ticket is valid.
+
+        Expected behavior:
+        Response returned by auth_complete should include the correspoding values when the ticket is valid
+        """
+        service_response = {}
+        request = Mock(GET=service_response)
+
+        self.assertRaises(AuthMissingParameter, self.cas_backend.auth_complete, request=request)
+
     @unpack
     @data(
         {


### PR DESCRIPTION
**Description:** When ticket is not in the request of auth_complete the platform raises an AuthMissingParameter. For some cases it's correct but may not be functional for production use cases.

A setting (`REDIRECT_WITHOUT_TICKET`) is configured to make a redirection to the login page.

Tests are added too.

**Testing instructions:**
1. Configure the setting `REDIRECT_WITHOUT_TICKET` as `True`.
2. Go to the following link:  http://local.overhang.io:8000/auth/complete/centralized-auth-service/?next=/
3. It should redirect you to the login page or if tpa_hint is configured you should be in the corresponding authentication page